### PR TITLE
Separating the deployer from the owner

### DIFF
--- a/contracts/Protected.sol
+++ b/contracts/Protected.sol
@@ -205,4 +205,8 @@ contract Protected is IProtected, ERC721Receiver, OwnableUpgradeable, ERC721Enum
       revert UnsupportedAsset();
     }
   }
+
+  function isOwnerOfAsset(uint protectorId, address asset, uint256 id) external view override returns (bool) {
+    return _deposits[asset][id][protectorId] > 0;
+  }
 }

--- a/contracts/Protected.sol
+++ b/contracts/Protected.sol
@@ -110,10 +110,12 @@ contract Protected is IProtected, ERC721Receiver, OwnableUpgradeable, ERC721Enum
     return IERC165Upgradeable(asset).supportsInterface(type(IERC1155Upgradeable).interfaceId);
   }
 
-  function _validateAndEmitEvent(uint256 protectorId,
+  function _validateAndEmitEvent(
+    uint256 protectorId,
     address asset,
     uint256 id,
-    uint amount) internal {
+    uint256 amount
+  ) internal {
     if (ownerOf(protectorId) == _msgSender() || allowAll[protectorId] || allowList[protectorId][_msgSender()]) {
       _deposits[asset][id][protectorId] += amount;
       emit Deposit(protectorId, asset, id, amount);
@@ -230,7 +232,11 @@ contract Protected is IProtected, ERC721Receiver, OwnableUpgradeable, ERC721Enum
     }
   }
 
-  function ownsAsset(uint protectorId, address asset, uint256 id) external view override returns (uint256) {
+  function ownsAsset(
+    uint256 protectorId,
+    address asset,
+    uint256 id
+  ) external view override returns (uint256) {
     return _deposits[asset][id][protectorId];
   }
 }

--- a/contracts/Protected.sol
+++ b/contracts/Protected.sol
@@ -14,6 +14,8 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "./interfaces/IProtected.sol";
 import "./utils/ERC721Receiver.sol";
 
+import "hardhat/console.sol";
+
 contract Protected is IProtected, ERC721Receiver, OwnableUpgradeable, ERC721EnumerableSubordinateUpgradeable, UUPSUpgradeable {
   modifier onlyProtectorOwner(uint256 protectorId) {
     if (ownerOf(protectorId) != msg.sender) {
@@ -108,13 +110,10 @@ contract Protected is IProtected, ERC721Receiver, OwnableUpgradeable, ERC721Enum
     return IERC165Upgradeable(asset).supportsInterface(type(IERC1155Upgradeable).interfaceId);
   }
 
-  // transfer asset from a wallet to a protected
-  function depositAsset(
-    uint256 protectorId,
+  function _validateAndEmitEvent(uint256 protectorId,
     address asset,
     uint256 id,
-    uint256 amount
-  ) external override {
+    uint amount) internal {
     if (ownerOf(protectorId) == _msgSender() || allowAll[protectorId] || allowList[protectorId][_msgSender()]) {
       _deposits[asset][id][protectorId] += amount;
       emit Deposit(protectorId, asset, id, amount);
@@ -124,17 +123,42 @@ contract Protected is IProtected, ERC721Receiver, OwnableUpgradeable, ERC721Enum
       );
       emit UnconfirmedDeposit(protectorId, _unconfirmedDeposits[protectorId].length - 1);
     } else revert NotAllowed();
-    // it will revert if the protected has not been approved to spend the asset
+  }
+
+  function depositNFT(
+    uint256 protectorId,
+    address asset,
+    uint256 id
+  ) external override {
+    _validateAndEmitEvent(protectorId, asset, id, 1);
     if (_isNFT(asset)) {
-      if (amount != 1) revert InvalidAmount();
       IERC721Upgradeable(asset).safeTransferFrom(_msgSender(), address(this), id);
-    } else if (_isFT(asset)) {
-      if (id != 0) revert InvalidId();
-      IERC20Upgradeable(asset).transferFrom(_msgSender(), address(this), amount);
-    } else if (_isSFT(asset)) {
+    } else {
+      revert InvalidAsset();
+    }
+  }
+
+  function depositFT(
+    uint256 protectorId,
+    address asset,
+    uint256 amount
+  ) external override {
+    _validateAndEmitEvent(protectorId, asset, 0, amount);
+    bool transferred = IERC20Upgradeable(asset).transferFrom(_msgSender(), address(this), amount);
+    if (!transferred) revert TransferFailed();
+  }
+
+  function depositSFT(
+    uint256 protectorId,
+    address asset,
+    uint256 id,
+    uint256 amount
+  ) external override {
+    _validateAndEmitEvent(protectorId, asset, id, amount);
+    if (_isSFT(asset)) {
       IERC1155Upgradeable(asset).safeTransferFrom(_msgSender(), address(this), id, amount, "");
     } else {
-      revert UnsupportedAsset();
+      revert InvalidAsset();
     }
   }
 
@@ -159,7 +183,7 @@ contract Protected is IProtected, ERC721Receiver, OwnableUpgradeable, ERC721Enum
       IERC1155Upgradeable(deposit.asset).safeTransferFrom(address(this), _msgSender(), deposit.id, deposit.amount, "");
     } else {
       // should never happen
-      revert UnsupportedAsset();
+      revert InvalidAsset();
     }
   }
 
@@ -202,11 +226,11 @@ contract Protected is IProtected, ERC721Receiver, OwnableUpgradeable, ERC721Enum
       IERC1155Upgradeable(asset).safeTransferFrom(address(this), _msgSender(), id, amount, "");
     } else {
       // should never happen
-      revert UnsupportedAsset();
+      revert InvalidAsset();
     }
   }
 
-  function isOwnerOfAsset(uint protectorId, address asset, uint256 id) external view override returns (bool) {
-    return _deposits[asset][id][protectorId] > 0;
+  function ownsAsset(uint protectorId, address asset, uint256 id) external view override returns (uint256) {
+    return _deposits[asset][id][protectorId];
   }
 }

--- a/contracts/Protector.sol
+++ b/contracts/Protector.sol
@@ -7,42 +7,79 @@ import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 import "./interfaces/IProtector.sol";
 
-contract Protector is IProtector, Initializable, ERC721Upgradeable, ERC721EnumerableUpgradeable, OwnableUpgradeable {
+contract Protector is
+  IProtector,
+  Initializable,
+  ERC721Upgradeable,
+  ERC721EnumerableUpgradeable,
+  OwnableUpgradeable,
+  UUPSUpgradeable
+{
+  // For security reason, this must be the protocol deployer and
+  // it will be different from the token owner. It is necessary to
+  // let the protocol deployer to be able to upgrade the contract,
+  // while the owner can still get the royalties coming from any
+  // token's sale, execute governance functions, mint the tokens, etc.
+  address public contractDeployer;
+
   // tokenId => isApprovable
   mapping(uint256 => bool) private _approvable;
 
-  function __Protector_init(string memory name_, string memory symbol_) public initializer {
+  modifier onlyDeployer() {
+    if (_msgSender() != contractDeployer) revert NotTheContractDeployer();
+    _;
+  }
+
+  // solhint-disable-next-line
+  function __Protector_init(
+    address contractOwner,
+    string memory name_,
+    string memory symbol_
+  ) public initializer {
+    contractDeployer = msg.sender;
+    _transferOwnership(contractOwner);
     __ERC721_init(name_, symbol_);
     __ERC721Enumerable_init();
-    __Ownable_init();
+    __UUPSUpgradeable_init();
+  }
+
+  function updateDeployer(address newDeployer) external onlyDeployer {
+    if (address(newDeployer) == address(0)) revert InvalidAddress();
+    // after the initial deployment, the deployer can be moved to
+    // a multisig wallet, managed by a DAO, etc.
+    contractDeployer = newDeployer;
+  }
+
+  function _authorizeUpgrade(address) internal override onlyDeployer {
+    // empty but needed to be sure that only PPP deployer can upgrade the contract
   }
 
   // The following functions are overrides required by Solidity.
-
   function _beforeTokenTransfer(
     address from,
     address to,
     uint256 tokenId,
     uint256 batchSize
-  ) internal override(ERC721Upgradeable, ERC721EnumerableUpgradeable) {
+  ) internal virtual override(ERC721Upgradeable, ERC721EnumerableUpgradeable) {
     super._beforeTokenTransfer(from, to, tokenId, batchSize);
   }
 
   function supportsInterface(bytes4 interfaceId)
     public
     view
+    virtual
     override(ERC721Upgradeable, ERC721EnumerableUpgradeable)
     returns (bool)
   {
     return super.supportsInterface(interfaceId);
   }
 
-  // manage approvability
-
-  function makeApprovable(uint256 tokenId, bool status) external override {
+  // manage approvals
+  function makeApprovable(uint256 tokenId, bool status) external virtual override {
     if (ownerOf(tokenId) != _msgSender()) revert NotTheTokenOwner();
     if (status) {
       _approvable[tokenId] = true;
@@ -54,7 +91,7 @@ contract Protector is IProtector, Initializable, ERC721Upgradeable, ERC721Enumer
 
   // Returns true if the protector is approvable.
   // It should revert if the token does not exist.
-  function isApprovable(uint256 tokenId) external view override returns (bool) {
+  function isApprovable(uint256 tokenId) external view virtual override returns (bool) {
     return _approvable[tokenId];
   }
 
@@ -76,7 +113,15 @@ contract Protector is IProtector, Initializable, ERC721Upgradeable, ERC721Enumer
     revert NotApprovableForAll();
   }
 
-  function isApprovedForAll(address, address) public view virtual override(ERC721Upgradeable, IERC721Upgradeable) returns (bool) {
+  function isApprovedForAll(address, address)
+    public
+    view
+    virtual
+    override(ERC721Upgradeable, IERC721Upgradeable)
+    returns (bool)
+  {
     return false;
   }
+
+  uint256[50] private __gap;
 }

--- a/contracts/interfaces/IProtected.sol
+++ b/contracts/interfaces/IProtected.sol
@@ -19,7 +19,7 @@ interface IProtected {
   event Withdrawal(uint256 indexed protectorId, address indexed asset, uint256 indexed id, uint256 amount);
 
   error NotAllowed();
-  error UnsupportedAsset();
+  error InvalidAsset();
   error InvalidAmount();
   error InvalidId();
   error Unauthorized();
@@ -27,6 +27,7 @@ interface IProtected {
   error InconsistentLengths();
   error UnconfirmedDepositNotExpiredYet();
   error InsufficientBalance();
+  error TransferFailed();
 
   struct WaitingDeposit {
     address sender;
@@ -44,7 +45,19 @@ interface IProtected {
     bool[] memory allowListStatus_
   ) external;
 
-  function depositAsset(
+  function depositNFT(
+    uint256 protectorId,
+    address asset,
+    uint256 id
+  ) external;
+
+  function depositFT(
+    uint256 protectorId,
+    address asset,
+    uint256 amount
+  ) external;
+
+  function depositSFT(
     uint256 protectorId,
     address asset,
     uint256 id,
@@ -71,5 +84,5 @@ interface IProtected {
     uint256 amount
   ) external;
 
-  function isOwnerOfAsset(uint protectorId, address asset, uint256 id) external view returns (bool);
+  function ownsAsset(uint protectorId, address asset, uint256 id) external view returns (uint);
 }

--- a/contracts/interfaces/IProtected.sol
+++ b/contracts/interfaces/IProtected.sol
@@ -70,4 +70,6 @@ interface IProtected {
     uint256 id,
     uint256 amount
   ) external;
+
+  function isOwnerOfAsset(uint protectorId, address asset, uint256 id) external view returns (bool);
 }

--- a/contracts/interfaces/IProtected.sol
+++ b/contracts/interfaces/IProtected.sol
@@ -84,5 +84,9 @@ interface IProtected {
     uint256 amount
   ) external;
 
-  function ownsAsset(uint protectorId, address asset, uint256 id) external view returns (uint);
+  function ownsAsset(
+    uint256 protectorId,
+    address asset,
+    uint256 id
+  ) external view returns (uint256);
 }

--- a/contracts/interfaces/IProtector.sol
+++ b/contracts/interfaces/IProtector.sol
@@ -9,6 +9,8 @@ interface IProtector {
   error NotTheTokenOwner();
   error NotApprovable();
   error NotApprovableForAll();
+  error NotTheContractDeployer();
+  error InvalidAddress();
 
   // A protector is by default not approvable.
   // To sell it on exchanges it must the made approvable.
@@ -19,5 +21,4 @@ interface IProtector {
   // It should revert if the token does not exist.
   // in any case it is not approvable for all
   function isApprovable(uint256 tokenId) external view returns (bool);
-
 }

--- a/contracts/mocks/Everdragons2ProtectorV2.sol
+++ b/contracts/mocks/Everdragons2ProtectorV2.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "../protectors/Everdragons2/Everdragons2Protector.sol";
+
+contract Everdragons2ProtectorV2 is Everdragons2Protector {
+
+  function version() public pure override returns (string memory) {
+    return "2.0.0";
+  }
+
+}

--- a/contracts/mocks/Everdragons2ProtectorV2.sol
+++ b/contracts/mocks/Everdragons2ProtectorV2.sol
@@ -4,9 +4,7 @@ pragma solidity ^0.8.17;
 import "../protectors/Everdragons2/Everdragons2Protector.sol";
 
 contract Everdragons2ProtectorV2 is Everdragons2Protector {
-
   function version() public pure override returns (string memory) {
     return "2.0.0";
   }
-
 }

--- a/contracts/mocks/Particle.sol
+++ b/contracts/mocks/Particle.sol
@@ -4,11 +4,10 @@ pragma solidity ^0.8.9;
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract Particel is ERC721, Ownable {
-  constructor() ERC721("Particel", "PTC") {}
+contract Particle is ERC721, Ownable {
+  constructor() ERC721("Particle", "PTC") {}
 
   function safeMint(address to, uint256 tokenId) public onlyOwner {
     _safeMint(to, tokenId);
   }
-
 }

--- a/contracts/mocks/StupidMonk.sol
+++ b/contracts/mocks/StupidMonk.sol
@@ -10,24 +10,20 @@ contract StupidMonk is ERC721, ERC721Enumerable, Ownable {
 
   // The following functions are overrides required by Solidity.
 
-  function _beforeTokenTransfer(address from, address to, uint256 tokenId, uint256 batchSize)
-  internal
-  override(ERC721, ERC721Enumerable)
-  {
+  function _beforeTokenTransfer(
+    address from,
+    address to,
+    uint256 tokenId,
+    uint256 batchSize
+  ) internal override(ERC721, ERC721Enumerable) {
     super._beforeTokenTransfer(from, to, tokenId, batchSize);
   }
 
-  function supportsInterface(bytes4 interfaceId)
-  public
-  view
-  override(ERC721, ERC721Enumerable)
-  returns (bool)
-  {
+  function supportsInterface(bytes4 interfaceId) public view override(ERC721, ERC721Enumerable) returns (bool) {
     return super.supportsInterface(interfaceId);
   }
 
   function safeMint(address to, uint256 tokenId) public onlyOwner {
     _safeMint(to, tokenId);
   }
-
 }

--- a/contracts/mocks/UselessWeapons.sol
+++ b/contracts/mocks/UselessWeapons.sol
@@ -11,15 +11,6 @@ contract UselessWeapons is ERC1155, Ownable {
     _setURI(newuri_);
   }
 
-  function mint(
-    address account,
-    uint256 id,
-    uint256 amount,
-    bytes memory data
-  ) public onlyOwner {
-    _mint(account, id, amount, data);
-  }
-
   function mintBatch(
     address to,
     uint256[] memory ids,

--- a/contracts/mocks/UselessWeapons.sol
+++ b/contracts/mocks/UselessWeapons.sol
@@ -11,17 +11,21 @@ contract UselessWeapons is ERC1155, Ownable {
     _setURI(newuri_);
   }
 
-  function mint(address account, uint256 id, uint256 amount, bytes memory data)
-  public
-  onlyOwner
-  {
+  function mint(
+    address account,
+    uint256 id,
+    uint256 amount,
+    bytes memory data
+  ) public onlyOwner {
     _mint(account, id, amount, data);
   }
 
-  function mintBatch(address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data)
-  public
-  onlyOwner
-  {
+  function mintBatch(
+    address to,
+    uint256[] memory ids,
+    uint256[] memory amounts,
+    bytes memory data
+  ) public onlyOwner {
     _mintBatch(to, ids, amounts, data);
   }
 }

--- a/contracts/protectors/Everdragons2/Everdragons2Protector.sol
+++ b/contracts/protectors/Everdragons2/Everdragons2Protector.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import "../Protector.sol";
+import "../../Protector.sol";
 
-contract Everdragons2Protector is Protector, UUPSUpgradeable {
+contract Everdragons2Protector is Protector {
   event TokenURIFrozen();
   event TokenURIUpdated(string uri);
 
@@ -13,18 +12,10 @@ contract Everdragons2Protector is Protector, UUPSUpgradeable {
   string private _baseTokenURI;
   bool private _baseTokenURIFrozen;
 
-  /// @custom:oz-upgrades-unsafe-allow constructor
-  constructor() {
-    _disableInitializers();
-  }
-
-  function initialize() public initializer {
-    __Protector_init("Everdragons2 Protector", "E2vtNFTa");
+  function initialize(address contractOwner) public initializer {
+    __Protector_init(contractOwner, "Everdragons2 Protector", "E2vtNFTa");
     _baseTokenURI = "https://everdragons2.com/protector/";
-    __UUPSUpgradeable_init();
   }
-
-  function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
   function safeMint(address to, uint256 tokenId) public onlyOwner {
     _safeMint(to, tokenId);

--- a/contracts/protectors/Everdragons2/Everdragons2Protector.sol
+++ b/contracts/protectors/Everdragons2/Everdragons2Protector.sol
@@ -17,6 +17,10 @@ contract Everdragons2Protector is Protector {
     _baseTokenURI = "https://everdragons2.com/protector/";
   }
 
+  function version() public pure virtual returns (string memory) {
+    return "1.0.0";
+  }
+
   function safeMint(address to, uint256 tokenId) public onlyOwner {
     _safeMint(to, tokenId);
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "npx hardhat test",
     "compile": "npx hardhat compile",
     "lint": "prettier --write 'contracts/**/*.sol' && solhint 'contracts/**/*.sol'",
-    "format": "npx prettier --write ./test/fixtures/**/*.js ./**/*.js"
+    "format": "npx prettier --write ./test/**/*.js ./**/*.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "test": "npx hardhat test",
     "compile": "npx hardhat compile",
     "lint": "prettier --write 'contracts/**/*.sol' && solhint 'contracts/**/*.sol'",
-    "format": "npx prettier --write ./test/**/*.js ./**/*.js"
+    "format": "npx prettier --write ./test/**/*.js ./**/*.js",
+    "postinstall": "./post-install.sh",
+    "prepare": "husky install"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "scripts": {
     "test": "npx hardhat test",
     "compile": "npx hardhat compile",
-    "lint": "prettier --write 'contracts/**/*.sol' && solhint 'contracts/**/*.sol'",
-    "format": "npx prettier --write ./test/**/*.js ./**/*.js",
+    "lint": "prettier --write 'contracts/**/*.sol' && solhint 'contracts/**/*.sol' && npx prettier --write ./test/**/*.js ./**/*.js",
     "postinstall": "./post-install.sh",
     "prepare": "husky install"
   },

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -39,9 +39,9 @@ const Helpers = {
     return contract;
   },
 
-  async deployContractUpgradeable(contractName, args = [], deployer = null) {
+  async deployContractUpgradeable(contractName, args = [], options) {
     const Contract = await this.ethers.getContractFactory(contractName);
-    const contract = await upgrades.deployProxy(Contract, args, deployer ? {from: deployer} : {});
+    const contract = await upgrades.deployProxy(Contract, args, options);
     await contract.deployed();
     return contract;
   },

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -39,9 +39,9 @@ const Helpers = {
     return contract;
   },
 
-  async deployContractUpgradeable(contractName, args = []) {
+  async deployContractUpgradeable(contractName, args = [], deployer = null) {
     const Contract = await this.ethers.getContractFactory(contractName);
-    const contract = await upgrades.deployProxy(Contract, args);
+    const contract = await upgrades.deployProxy(Contract, args, deployer ? {from: deployer} : {});
     await contract.deployed();
     return contract;
   },

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -67,7 +67,7 @@ const Helpers = {
     await this.ethers.provider.send("evm_mine");
   },
 
-  async amount(str) {
+  amount(str) {
     return this.ethers.utils.parseEther(str);
   },
 };

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -66,6 +66,10 @@ const Helpers = {
     await this.ethers.provider.send("evm_increaseTime", [offset]);
     await this.ethers.provider.send("evm_mine");
   },
+
+  async amount(str) {
+    return this.ethers.utils.parseEther(str);
+  },
 };
 
 module.exports = Helpers;

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,5 +1,5 @@
 const {expect} = require("chai");
-const {deployContractUpgradeable, deployContract} = require("./helpers");
+const {deployContractUpgradeable, deployContract, amount} = require("./helpers");
 
 describe("Integration", function () {
   let e2, e2Protected;
@@ -14,25 +14,53 @@ describe("Integration", function () {
 
   beforeEach(async function () {
     e2 = await deployContractUpgradeable("Everdragons2Protector", [e2Owner.address]);
-    await e2.safeMint(bob.address, 1);
-    await e2.safeMint(bob.address, 2);
-    await e2.safeMint(bob.address, 3);
-    await e2.safeMint(bob.address, 4);
-    await e2.safeMint(alice.address, 5);
-    await e2.safeMint(alice.address, 6);
+    await e2.connect(e2Owner).safeMint(bob.address, 1);
+    await e2.connect(e2Owner).safeMint(bob.address, 2);
+    await e2.connect(e2Owner).safeMint(bob.address, 3);
+    await e2.connect(e2Owner).safeMint(bob.address, 4);
+    await e2.connect(e2Owner).safeMint(alice.address, 5);
+    await e2.connect(e2Owner).safeMint(alice.address, 6);
 
     e2Protected = await deployContractUpgradeable("Protected", [e2.address]);
 
+    // erc20
     bulls = await deployContract("Bulls");
+    await bulls.mint(bob.address, amount("90000"));
+    await bulls.mint(john.address, amount("60000"));
+    await bulls.mint(jane.address, amount("100000"));
+
     fatBelly = await deployContract("FatBelly");
+    await fatBelly.mint(alice.address, amount("10000000"));
+    await fatBelly.mint(john.address, amount("2000000"));
+    await fatBelly.mint(fred.address, amount("30000000"));
+
+    // erc721
     particle = await deployContract("Particle");
+    await particle.safeMint(alice.address, 1);
+    await particle.safeMint(bob.address, 2);
+    await particle.safeMint(john.address, 3);
+
     stupidMonk = await deployContract("StupidMonk");
+    await stupidMonk.safeMint(bob.address, 1);
+    await stupidMonk.safeMint(alice.address, 2);
+    await stupidMonk.safeMint(john.address, 3);
+
+    // erc1155
     uselessWeapons = await deployContract("UselessWeapons");
+    await uselessWeapons.mintBatch(bob.address, [1, 2], [5, 2], "0x00");
+    await uselessWeapons.mintBatch(alice.address, [2], [2], "0x00");
+    await uselessWeapons.mintBatch(john.address, [3, 4], [10, 1], "0x00");
   });
 
   async function configure(protectorId, allowAll_, allowWithConfirmation_, allowList_, allowListStatus_) {
     await e2Protected.configure(protectorId, allowAll_, allowWithConfirmation_, allowList_, allowListStatus_);
   }
 
-  it("should verify the flow", async function () {});
+  it("should verify the flow", async function () {
+    // bob creates a vault depositing some assets
+    await particle.connect(bob).setApprovalForAll(e2Protected.address, true);
+    await e2Protected.connect(bob).depositAsset(1, particle.address, 2, 1);
+    expect(await e2Protected.isOwnerOfAsset(1, particle.address, 2)).to.be.true;
+
+  });
 });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,25 +1,19 @@
 const {expect} = require("chai");
-const {deployContractUpgradeable, deployContract, number} = require("./helpers");
+const {deployContractUpgradeable, deployContract} = require("./helpers");
 
 describe("Integration", function () {
-  let e2;
-  let protectedToken;
+  let e2, e2Protected;
   // mocks
-  let bulls;
-  let particel;
-  let fatBelly
-  let stupidMonk
-  let uselessWeapons
-
-  let owner, bob, alice, fred, john, jane;
+  let bulls, particle, fatBelly, stupidMonk, uselessWeapons;
+  // wallets
+  let owner, bob, alice, fred, john, jane, e2Owner, trtOwner;
 
   before(async function () {
-    [owner, bob, alice, fred, john, jane] = await ethers.getSigners();
+    [owner, bob, alice, fred, john, jane, e2Owner, trtOwner] = await ethers.getSigners();
   });
 
   beforeEach(async function () {
-    e2 = await deployContractUpgradeable("Everdragons2Protector");
-
+    e2 = await deployContractUpgradeable("Everdragons2Protector", [e2Owner.address]);
     await e2.safeMint(bob.address, 1);
     await e2.safeMint(bob.address, 2);
     await e2.safeMint(bob.address, 3);
@@ -27,20 +21,18 @@ describe("Integration", function () {
     await e2.safeMint(alice.address, 5);
     await e2.safeMint(alice.address, 6);
 
-    protectedToken = await deployContractUpgradeable("Protected", [e2.address]);
+    e2Protected = await deployContractUpgradeable("Protected", [e2.address]);
 
     bulls = await deployContract("Bulls");
     fatBelly = await deployContract("FatBelly");
-    particel = await deployContract("Particel");
+    particle = await deployContract("Particle");
     stupidMonk = await deployContract("StupidMonk");
     uselessWeapons = await deployContract("UselessWeapons");
-
   });
 
   async function configure(protectorId, allowAll_, allowWithConfirmation_, allowList_, allowListStatus_) {
-    await protectedToken.configure(protectorId, allowAll_, allowWithConfirmation_, allowList_, allowListStatus_);
+    await e2Protected.configure(protectorId, allowAll_, allowWithConfirmation_, allowList_, allowListStatus_);
   }
 
-  it("should verify the flow", async function () {
-  });
+  it("should verify the flow", async function () {});
 });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -56,11 +56,21 @@ describe("Integration", function () {
     await e2Protected.configure(protectorId, allowAll_, allowWithConfirmation_, allowList_, allowListStatus_);
   }
 
-  it("should verify the flow", async function () {
-    // bob creates a vault depositing some assets
+  it("should create a vault and add more assets to it", async function () {
+    // bob creates a vault depositing a particle token
     await particle.connect(bob).setApprovalForAll(e2Protected.address, true);
-    await e2Protected.connect(bob).depositAsset(1, particle.address, 2, 1);
-    expect(await e2Protected.isOwnerOfAsset(1, particle.address, 2)).to.be.true;
+    await e2Protected.connect(bob).depositNFT(1, particle.address, 2);
+    expect(await e2Protected.ownsAsset(1, particle.address, 2)).equal(1);
+
+    // bob adds a stupidMonk token to his vault
+    await stupidMonk.connect(bob).setApprovalForAll(e2Protected.address, true);
+    await e2Protected.connect(bob).depositNFT(1, stupidMonk.address, 1);
+    expect(await e2Protected.ownsAsset(1, stupidMonk.address, 1)).equal(1)
+
+    // bob adds some bulls tokens to his vault
+    await bulls.connect(bob).approve(e2Protected.address, amount("10000"));
+    await e2Protected.connect(bob).depositFT(1, bulls.address, amount("5000"));
+    expect(await e2Protected.ownsAsset(1, bulls.address, 0)).equal(amount("5000"));
 
   });
 });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -13,7 +13,7 @@ describe("Integration", function () {
   });
 
   beforeEach(async function () {
-    e2 = await deployContractUpgradeable("Everdragons2Protector", [e2Owner.address], deployer);
+    e2 = await deployContractUpgradeable("Everdragons2Protector", [e2Owner.address], {from: deployer});
     await e2.connect(e2Owner).safeMint(bob.address, 1);
     await e2.connect(e2Owner).safeMint(bob.address, 2);
     await e2.connect(e2Owner).safeMint(bob.address, 3);

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -6,14 +6,14 @@ describe("Integration", function () {
   // mocks
   let bulls, particle, fatBelly, stupidMonk, uselessWeapons;
   // wallets
-  let deployer, bob, alice, fred, john, jane, e2Owner, trtOwner;
+  let defWallet, deployer, bob, alice, fred, john, jane, e2Owner, trtOwner;
 
   before(async function () {
     [deployer, bob, alice, fred, john, jane, e2Owner, trtOwner] = await ethers.getSigners();
   });
 
   beforeEach(async function () {
-    e2 = await deployContractUpgradeable("Everdragons2Protector", [e2Owner.address]);
+    e2 = await deployContractUpgradeable("Everdragons2Protector", [e2Owner.address], deployer);
     await e2.connect(e2Owner).safeMint(bob.address, 1);
     await e2.connect(e2Owner).safeMint(bob.address, 2);
     await e2.connect(e2Owner).safeMint(bob.address, 3);


### PR DESCRIPTION
The PPP project must be the only one capable of upgrading a protector contract, for security reasons.
Still, the projects' tokens must be owned by the projects' owners. This PR makes a difference between the twos.