### PR TITLE
Implementing second factor for protector transfers

### DIFF
--- a/contracts/interfaces/IERC721Approvable.sol
+++ b/contracts/interfaces/IERC721Approvable.sol
@@ -27,7 +27,8 @@ interface IERC721Approvable {
   function isApprovable(uint256 tokenId) external view returns (bool);
 
   // Returns true if the token is approvable by default.
-  function defaultApprovable() external pure returns (bool);
+  // It may be pure, but view leaves more flexibility to the implementer.
+  function defaultApprovable() external view returns (bool);
 
   // A contract implementing this interface should not allow
   // the approval for all. So, any actor validating this interface

--- a/contracts/interfaces/IProtector.sol
+++ b/contracts/interfaces/IProtector.sol
@@ -6,10 +6,43 @@ pragma solidity ^0.8.17;
 import "./IERC721Approvable.sol";
 
 interface IProtector is IERC721Approvable {
+  event TransferInitializerChanged(address indexed owner, address indexed transferInitializer, bool status);
+  event TransferStarted(address indexed transferInitializer, uint256 indexed tokenId, address indexed to);
+
   error NotTheTokenOwner();
   error NotApprovable();
   error NotApprovableForAll();
   error NotTheContractDeployer();
   error InvalidAddress();
   error TokenDoesNotExist();
+  error SenderDoesNotOwnAnyToken();
+  error TransferInitializerNotFound();
+  error TokenAlreadyBeingTransferred();
+  error SetByAnotherOwner();
+  error TransferInitializerAlreadySet();
+  error NotATransferInitializer();
+  error NotOwnByRelatedOwner();
+  error TransferExpired();
+  error TransferNotPermitted();
+
+  struct CurrentTransfer {
+    address starter;
+    address to;
+    uint256 expiresAt;
+    bool approved;
+  }
+
+  function updateDeployer(address newDeployer) external;
+
+  function setTransferInitializer(address wallet) external;
+
+  function onlyTransferInitializer(uint256 tokenId) external view returns (bool);
+
+  function startTransfer(
+    uint256 tokenId,
+    address to,
+    uint256 expiresIn
+  ) external;
+
+  function completeTransfer(uint256 tokenId) external;
 }


### PR DESCRIPTION
This adds a second wallet that must start the transfer if set.